### PR TITLE
feat: Add environment variable support for feature flags

### DIFF
--- a/backend/flags/ENVIRONMENT_VARIABLES.md
+++ b/backend/flags/ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,219 @@
+# Feature Flags - Environment Variables Support
+
+## Overview
+
+Helium AI now supports enabling feature flags using environment variables, making it easier to deploy and manage features in production Docker environments.
+
+## Quick Start
+
+### Enable All Features
+
+Add these environment variables to your Docker deployment:
+
+```bash
+# Feature Flags - Enable all features
+FLAG_CUSTOM_AGENTS=true
+FLAG_KNOWLEDGE_BASE=true
+FLAG_MCP_MODULE=true
+FLAG_TEMPLATES_API=true
+FLAG_TRIGGERS_API=true
+FLAG_WORKFLOWS_API=true
+FLAG_PIPEDREAM=true
+FLAG_CREDENTIALS_API=true
+FLAG_SUNA_DEFAULT_AGENT=true
+```
+
+### Docker Compose Example
+
+```yaml
+version: "3.8"
+services:
+  backend:
+    build: ./backend
+    environment:
+      # Feature Flags
+      - FLAG_CUSTOM_AGENTS=true
+      - FLAG_KNOWLEDGE_BASE=true
+      - FLAG_MCP_MODULE=true
+      - FLAG_TEMPLATES_API=true
+      - FLAG_TRIGGERS_API=true
+      - FLAG_WORKFLOWS_API=true
+      - FLAG_PIPEDREAM=true
+      - FLAG_CREDENTIALS_API=true
+      - FLAG_SUNA_DEFAULT_AGENT=true
+      
+      # Other environment variables...
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    depends_on:
+      - redis
+```
+
+## Available Feature Flags
+
+| Feature Flag | Environment Variable | Description |
+|--------------|---------------------|-------------|
+| `custom_agents` | `FLAG_CUSTOM_AGENTS` | Enable custom agent creation and management |
+| `knowledge_base` | `FLAG_KNOWLEDGE_BASE` | Enable knowledge base functionality |
+| `mcp_module` | `FLAG_MCP_MODULE` | Enable MCP (Model Context Protocol) module |
+| `templates_api` | `FLAG_TEMPLATES_API` | Enable templates API |
+| `triggers_api` | `FLAG_TRIGGERS_API` | Enable triggers API |
+| `workflows_api` | `FLAG_WORKFLOWS_API` | Enable workflows API |
+| `pipedream` | `FLAG_PIPEDREAM` | Enable Pipedream integration |
+| `credentials_api` | `FLAG_CREDENTIALS_API` | Enable credentials API |
+| `suna_default_agent` | `FLAG_SUNA_DEFAULT_AGENT` | Enable Suna default agent |
+
+## Environment Variable Priority
+
+1. **Environment variables take precedence** - If `FLAG_KNOWLEDGE_BASE=true` is set, it will override any Redis setting
+2. **Redis fallback** - If no environment variable is set, the system checks Redis
+3. **Default behavior** - If neither environment variable nor Redis setting exists, the feature is disabled
+
+## Usage Examples
+
+### Enable Specific Features
+
+```bash
+# Enable only knowledge base and custom agents
+FLAG_KNOWLEDGE_BASE=true
+FLAG_CUSTOM_AGENTS=true
+```
+
+### Disable Features
+
+```bash
+# Disable a feature (set to false or any other value)
+FLAG_PIPEDREAM=false
+```
+
+### Check Current Status
+
+Use the API endpoint to check which flags are enabled:
+
+```bash
+# Get all feature flags
+curl http://your-backend:8000/feature-flags
+
+# Get available flags and their environment variables
+curl http://your-backend:8000/feature-flags/available
+
+# Get specific flag status
+curl http://your-backend:8000/feature-flags/knowledge_base
+```
+
+## API Endpoints
+
+### Get All Feature Flags
+```bash
+GET /feature-flags
+```
+
+Response:
+```json
+{
+  "flags": {
+    "knowledge_base": true,
+    "custom_agents": true,
+    "mcp_module": false
+  }
+}
+```
+
+### Get Available Flags
+```bash
+GET /feature-flags/available
+```
+
+Response:
+```json
+{
+  "available_flags": {
+    "knowledge_base": {
+      "environment_variable": "FLAG_KNOWLEDGE_BASE",
+      "environment_value": true,
+      "description": "Set FLAG_KNOWLEDGE_BASE=true to enable this feature"
+    }
+  },
+  "usage": "Set environment variables like FLAG_KNOWLEDGE_BASE=true to enable features"
+}
+```
+
+### Get Specific Flag
+```bash
+GET /feature-flags/{flag_name}
+```
+
+Response:
+```json
+{
+  "flag_name": "knowledge_base",
+  "enabled": true,
+  "details": {
+    "description": "Knowledge base feature",
+    "updated_at": "2024-01-15T10:30:00Z"
+  },
+  "environment_info": {
+    "environment_variable": "FLAG_KNOWLEDGE_BASE",
+    "environment_value": true,
+    "source": "environment"
+  }
+}
+```
+
+## Development
+
+### Testing Environment Variables
+
+You can test environment variables locally:
+
+```bash
+# Set environment variables for testing
+export FLAG_KNOWLEDGE_BASE=true
+export FLAG_CUSTOM_AGENTS=true
+
+# Run your application
+python -m uvicorn api:app --reload
+```
+
+### Checking Current Status
+
+Use the provided script to check current environment variable status:
+
+```bash
+cd backend/flags
+python3 enable_all_flags.py check
+```
+
+This will show you which flags are currently enabled via environment variables.
+
+## Migration from Redis
+
+If you were previously using Redis to manage feature flags, you can:
+
+1. **Keep using Redis** - Environment variables take precedence, so you can gradually migrate
+2. **Migrate to environment variables** - Set the environment variables and remove Redis flags
+3. **Use both** - Environment variables for production, Redis for development/testing
+
+## Troubleshooting
+
+### Flag Not Working
+
+1. **Check environment variable name** - Make sure it's in the correct format: `FLAG_{UPPERCASE_NAME}`
+2. **Check environment variable value** - Must be `true`, `t`, `yes`, `y`, or `1` (case insensitive)
+3. **Check application logs** - Look for flag-related log messages
+4. **Use API endpoints** - Check `/feature-flags/available` to see all available flags
+
+### Common Issues
+
+- **Flag name mismatch** - Environment variable names are uppercase with `FLAG_` prefix
+- **Value format** - Boolean values must be `true`/`false` (not `True`/`False`)
+- **Docker environment** - Make sure environment variables are properly passed to the container
+
+## Support
+
+For issues or questions about feature flags:
+
+1. Check the API endpoints for current status
+2. Review application logs for flag-related messages
+3. Use the `enable_all_flags.py` script to generate environment variables
+4. Consult the main README.md for additional documentation

--- a/backend/flags/api.py
+++ b/backend/flags/api.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from utils.logger import logger
-from .flags import list_flags, is_enabled, get_flag_details
+from .flags import list_flags, is_enabled, get_flag_details, get_available_flags, _check_env_flag
 
 router = APIRouter()
 
@@ -14,20 +14,56 @@ async def get_feature_flags():
         logger.error(f"Error fetching feature flags: {str(e)}")
         return {"flags": {}}
 
+@router.get("/feature-flags/available")
+async def get_available_feature_flags():
+    """Get all available feature flags and their environment variable names"""
+    try:
+        available_flags = get_available_flags()
+        flags_with_env = {}
+        
+        for flag_name, env_var in available_flags.items():
+            env_value = _check_env_flag(flag_name)
+            flags_with_env[flag_name] = {
+                "environment_variable": env_var,
+                "environment_value": env_value,
+                "description": f"Set {env_var}=true to enable this feature"
+            }
+        
+        return {
+            "available_flags": flags_with_env,
+            "usage": "Set environment variables like FLAG_KNOWLEDGE_BASE=true to enable features"
+        }
+    except Exception as e:
+        logger.error(f"Error fetching available feature flags: {str(e)}")
+        return {"available_flags": {}}
+
 @router.get("/feature-flags/{flag_name}")
 async def get_feature_flag(flag_name: str):
     try:
         enabled = await is_enabled(flag_name)
         details = await get_flag_details(flag_name)
+        
+        # Check if flag is set via environment variable
+        env_flag = _check_env_flag(flag_name)
+        env_info = None
+        if env_flag is not None:
+            env_info = {
+                "environment_variable": f"FLAG_{flag_name.upper()}",
+                "environment_value": env_flag,
+                "source": "environment"
+            }
+        
         return {
             "flag_name": flag_name,
             "enabled": enabled,
-            "details": details
+            "details": details,
+            "environment_info": env_info
         }
     except Exception as e:
         logger.error(f"Error fetching feature flag {flag_name}: {str(e)}")
         return {
             "flag_name": flag_name,
             "enabled": False,
-            "details": None
+            "details": None,
+            "environment_info": None
         } 

--- a/backend/flags/enable_all_flags.py
+++ b/backend/flags/enable_all_flags.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Script to enable all available feature flags via environment variables.
+This script generates the environment variables you need to add to your Docker deployment.
+"""
+
+import os
+import sys
+
+def get_available_flags():
+    """
+    Get all available feature flags and their corresponding environment variable names.
+    Returns a dictionary mapping flag names to their environment variable names.
+    """
+    return {
+        "custom_agents": "FLAG_CUSTOM_AGENTS",
+        "mcp_module": "FLAG_MCP_MODULE", 
+        "templates_api": "FLAG_TEMPLATES_API",
+        "triggers_api": "FLAG_TRIGGERS_API",
+        "workflows_api": "FLAG_WORKFLOWS_API",
+        "knowledge_base": "FLAG_KNOWLEDGE_BASE",
+        "pipedream": "FLAG_PIPEDREAM",
+        "credentials_api": "FLAG_CREDENTIALS_API",
+        "suna_default_agent": "FLAG_SUNA_DEFAULT_AGENT"
+    }
+
+def generate_env_vars():
+    """Generate environment variables for all available flags"""
+    available_flags = get_available_flags()
+    
+    print("🚀 Helium AI Feature Flags - Environment Variables")
+    print("=" * 50)
+    print()
+    print("Add these environment variables to your Docker deployment to enable all features:")
+    print()
+    
+    for flag_name, env_var in available_flags.items():
+        print(f"# Enable {flag_name.replace('_', ' ').title()}")
+        print(f"{env_var}=true")
+        print()
+    
+    print("=" * 50)
+    print("📝 Example .env file for Docker deployment:")
+    print()
+    print("# Feature Flags - Enable all features")
+    for flag_name, env_var in available_flags.items():
+        print(f"{env_var}=true")
+    print()
+    print("# Other environment variables...")
+    print("REDIS_HOST=redis")
+    print("REDIS_PORT=6379")
+    print("REDIS_PASSWORD=")
+    print()
+    print("=" * 50)
+    print("🐳 Docker Compose example:")
+    print()
+    print("version: \"3.8\"")
+    print("services:")
+    print("  backend:")
+    print("    build: ./backend")
+    print("    environment:")
+    print("      # Feature Flags")
+    for flag_name, env_var in available_flags.items():
+        print(f"      - {env_var}=true")
+    print("      # Other environment variables...")
+    print("      - REDIS_HOST=redis")
+    print("      - REDIS_PORT=6379")
+    print("    depends_on:")
+    print("      - redis")
+
+def check_current_flags():
+    """Check which flags are currently enabled via environment variables"""
+    available_flags = get_available_flags()
+    
+    print("🔍 Current Environment Variable Status:")
+    print("=" * 40)
+    print()
+    
+    enabled_count = 0
+    for flag_name, env_var in available_flags.items():
+        env_value = os.getenv(env_var)
+        if env_value is not None:
+            enabled = env_value.lower() in ('true', 't', 'yes', 'y', '1')
+            status = "✅ ENABLED" if enabled else "❌ DISABLED"
+            print(f"{status} {flag_name} ({env_var}={env_value})")
+            if enabled:
+                enabled_count += 1
+        else:
+            print(f"⚪ NOT SET {flag_name} ({env_var})")
+    
+    print()
+    print(f"📊 Summary: {enabled_count}/{len(available_flags)} flags enabled via environment variables")
+    print()
+    print("💡 Tip: Set environment variables to enable features without Redis configuration")
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "check":
+        check_current_flags()
+    else:
+        generate_env_vars()

--- a/backend/flags/flags.py
+++ b/backend/flags/flags.py
@@ -10,6 +10,40 @@ from services import redis
 
 logger = logging.getLogger(__name__)
 
+def _check_env_flag(key: str) -> Optional[bool]:
+    """
+    Check if a feature flag is enabled via environment variable.
+    Environment variables should be in the format: FLAG_{UPPERCASE_KEY}
+    Example: FLAG_KNOWLEDGE_BASE=true
+    """
+    env_key = f"FLAG_{key.upper()}"
+    env_value = os.getenv(env_key)
+    
+    if env_value is not None:
+        # Convert string to boolean
+        enabled = env_value.lower() in ('true', 't', 'yes', 'y', '1')
+        logger.info(f"Feature flag {key} set to {enabled} via environment variable {env_key}")
+        return enabled
+    
+    return None
+
+def get_available_flags() -> Dict[str, str]:
+    """
+    Get all available feature flags and their corresponding environment variable names.
+    Returns a dictionary mapping flag names to their environment variable names.
+    """
+    return {
+        "custom_agents": "FLAG_CUSTOM_AGENTS",
+        "mcp_module": "FLAG_MCP_MODULE", 
+        "templates_api": "FLAG_TEMPLATES_API",
+        "triggers_api": "FLAG_TRIGGERS_API",
+        "workflows_api": "FLAG_WORKFLOWS_API",
+        "knowledge_base": "FLAG_KNOWLEDGE_BASE",
+        "pipedream": "FLAG_PIPEDREAM",
+        "credentials_api": "FLAG_CREDENTIALS_API",
+        "suna_default_agent": "FLAG_SUNA_DEFAULT_AGENT"
+    }
+
 class FeatureFlagManager:
     def __init__(self):
         """Initialize with existing Redis service"""
@@ -39,6 +73,12 @@ class FeatureFlagManager:
     
     async def is_enabled(self, key: str) -> bool:
         """Check if a feature flag is enabled"""
+        # First check environment variable
+        env_flag = _check_env_flag(key)
+        if env_flag is not None:
+            return env_flag
+        
+        # Fall back to Redis
         try:
             flag_key = f"{self.flag_prefix}{key}"
             redis_client = await redis.get_client()
@@ -77,18 +117,28 @@ class FeatureFlagManager:
     
     async def list_flags(self) -> Dict[str, bool]:
         """List all feature flags with their status"""
+        flags = {}
+        
+        # First check environment variables for all available flags
+        available_flags = get_available_flags()
+        for flag_name in available_flags.keys():
+            env_flag = _check_env_flag(flag_name)
+            if env_flag is not None:
+                flags[flag_name] = env_flag
+        
+        # Then check Redis for any additional flags
         try:
             redis_client = await redis.get_client()
             flag_keys = await redis_client.smembers(self.flag_list_key)
-            flags = {}
             
             for key in flag_keys:
-                flags[key] = await self.is_enabled(key)
-            
-            return flags
+                # Only add if not already set by environment variable
+                if key not in flags:
+                    flags[key] = await self.is_enabled(key)
         except Exception as e:
-            logger.error(f"Failed to list feature flags: {e}")
-            return {}
+            logger.error(f"Failed to list feature flags from Redis: {e}")
+        
+        return flags
     
     async def get_all_flags_details(self) -> Dict[str, Dict[str, str]]:
         """Get all feature flags with detailed information"""


### PR DESCRIPTION
- Add environment variable support for feature flags (FLAG_KNOWLEDGE_BASE=true, etc.)
- Environment variables take precedence over Redis settings
- Add new API endpoint /feature-flags/available to show all available flags
- Create enable_all_flags.py script for generating environment variables
- Add comprehensive documentation in ENVIRONMENT_VARIABLES.md
- Update README.md with environment variable usage examples
- Maintain backward compatibility with existing Redis-based flags

This enables easy feature flag management in production Docker deployments.