### PR TITLE
Fix markdown task list rendering with proper green checkboxes for completed tasks

### DIFF
--- a/frontend/src/components/file-renderers/markdown-renderer.tsx
+++ b/frontend/src/components/file-renderers/markdown-renderer.tsx
@@ -95,7 +95,40 @@ export const MarkdownRenderer = forwardRef<
             ol: ({ node, ...props }) => (
               <ol className="list-decimal my-2" {...props} />
             ),
-            li: ({ node, ...props }) => <li className="my-1" {...props} />,
+            li: ({ node, ...props }) => {
+              // Check if this is a task list item (contains [x] or [ ])
+              const content = props.children as string;
+              const isTaskList = typeof content === 'string' && /^\[[ x]\]\s/.test(content);
+              
+              if (isTaskList) {
+                const isCompleted = content.startsWith('[x]');
+                const taskText = content.replace(/^\[[ x]\]\s/, '');
+                
+                return (
+                  <li className="flex items-start gap-3 my-2" {...props}>
+                    <div className="flex-shrink-0 mt-0.5">
+                      {isCompleted ? (
+                        <div className="w-4 h-4 rounded border-2 border-green-500 bg-green-500 flex items-center justify-center">
+                          <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                          </svg>
+                        </div>
+                      ) : (
+                        <div className="w-4 h-4 rounded border-2 border-zinc-400 dark:border-zinc-600 bg-transparent" />
+                      )}
+                    </div>
+                    <span className={cn(
+                      "flex-1",
+                      isCompleted && "text-green-700 dark:text-green-300 line-through"
+                    )}>
+                      {taskText}
+                    </span>
+                  </li>
+                );
+              }
+              
+              return <li className="my-1" {...props} />;
+            },
             blockquote: ({ node, ...props }) => (
               <blockquote
                 className="border-l-4 border-muted pl-4 italic my-2"

--- a/frontend/src/components/thread/tool-views/task-list/TaskListToolView.tsx
+++ b/frontend/src/components/thread/tool-views/task-list/TaskListToolView.tsx
@@ -15,11 +15,21 @@ const TaskItem: React.FC<{ task: Task; index: number }> = ({ task, index }) => {
 
   return (
     <div className="flex items-center gap-3 py-3 px-4 hover:bg-zinc-50/50 dark:hover:bg-zinc-800/50 transition-colors border-b border-zinc-100 dark:border-zinc-800 last:border-b-0">
-      {/* Status Icon */}
+      {/* Checkbox Status Indicator */}
       <div className="flex-shrink-0">
-        {isCompleted && <CircleCheck className="h-4 w-4 text-green-500 dark:text-green-400" />}
-        {isCancelled && <X className="h-4 w-4 text-red-500 dark:text-red-400" />}
-        {isPending && <Circle className="h-4 w-4 text-zinc-400 dark:text-zinc-600" />}
+        {isCompleted && (
+          <div className="w-4 h-4 rounded border-2 border-green-500 bg-green-500 flex items-center justify-center">
+            <Check className="h-3 w-3 text-white" />
+          </div>
+        )}
+        {isCancelled && (
+          <div className="w-4 h-4 rounded border-2 border-red-500 bg-red-500 flex items-center justify-center">
+            <X className="h-3 w-3 text-white" />
+          </div>
+        )}
+        {isPending && (
+          <div className="w-4 h-4 rounded border-2 border-zinc-400 dark:border-zinc-600 bg-transparent" />
+        )}
       </div>
 
       {/* Task Content */}
@@ -27,8 +37,8 @@ const TaskItem: React.FC<{ task: Task; index: number }> = ({ task, index }) => {
         <p
           className={cn(
             "text-sm leading-relaxed",
-            isCompleted && "text-zinc-900 dark:text-zinc-100",
-            isCancelled && "text-zinc-500 dark:text-zinc-400 line-through",
+            isCompleted && "text-green-700 dark:text-green-300 line-through",
+            isCancelled && "text-red-500 dark:text-red-400 line-through",
             isPending && "text-zinc-600 dark:text-zinc-300",
           )}
         >
@@ -42,17 +52,37 @@ const TaskItem: React.FC<{ task: Task; index: number }> = ({ task, index }) => {
 const SectionHeader: React.FC<{ section: Section }> = ({ section }) => {
   const totalTasks = section.tasks.length
   const completedTasks = section.tasks.filter((t) => t.status === "completed").length
+  const allCompleted = completedTasks === totalTasks && totalTasks > 0
 
   return (
-    <div className="flex items-center justify-between py-3 px-4 bg-zinc-50/80 dark:bg-zinc-900/80 border-b border-zinc-200 dark:border-zinc-700">
-      <h3 className="text-sm font-medium text-zinc-700 dark:text-zinc-300">{section.title}</h3>
+    <div className={cn(
+      "flex items-center justify-between py-3 px-4 border-b transition-colors",
+      allCompleted 
+        ? "bg-green-50/80 dark:bg-green-900/20 border-green-200 dark:border-green-800" 
+        : "bg-zinc-50/80 dark:bg-zinc-900/80 border-zinc-200 dark:border-zinc-700"
+    )}>
+      <h3 className={cn(
+        "text-sm font-medium",
+        allCompleted 
+          ? "text-green-800 dark:text-green-300" 
+          : "text-zinc-700 dark:text-zinc-300"
+      )}>
+        {section.title}
+        {allCompleted && <span className="ml-2">✅</span>}
+      </h3>
       <div className="flex items-center gap-2">
-        <Badge variant="outline" className="text-xs h-5 px-2 py-0 font-normal bg-white dark:bg-zinc-800">
+        <Badge variant="outline" className={cn(
+          "text-xs h-5 px-2 py-0 font-normal",
+          allCompleted 
+            ? "bg-green-100 text-green-800 border-green-300 dark:bg-green-800/30 dark:text-green-300 dark:border-green-700" 
+            : "bg-white dark:bg-zinc-800"
+        )}>
           {completedTasks}/{totalTasks}
         </Badge>
-        {completedTasks === totalTasks && totalTasks > 0 && (
-          <Badge variant="outline" className="text-xs h-5 px-2 py-0 bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800">
+        {allCompleted && (
+          <Badge variant="outline" className="text-xs h-5 px-2 py-0 bg-green-100 text-green-700 border-green-300 dark:bg-green-800/30 dark:text-green-300 dark:border-green-700">
             <Check className="h-3 w-3" />
+            Complete
           </Badge>
         )}
       </div>
@@ -102,15 +132,31 @@ export const TaskListToolView: React.FC<ToolViewProps> = ({
 
   return (
     <Card className="gap-0 flex border shadow-none border-t border-b-0 border-x-0 p-0 rounded-none flex-col h-full overflow-hidden bg-card">
-      <CardHeader className="h-14 bg-zinc-50/80 dark:bg-zinc-900/80 backdrop-blur-sm border-b p-2 px-4 space-y-2">
+      <CardHeader className={cn(
+        "h-14 bg-gradient-to-br backdrop-blur-sm border-b p-2 px-4 space-y-2 transition-colors",
+        completedTasks === totalTasks && totalTasks > 0
+          ? "from-green-50/80 to-green-100/60 dark:from-green-900/20 dark:to-green-800/10 border-green-200 dark:border-green-800"
+          : "from-zinc-50/80 to-zinc-100/60 dark:from-zinc-900/80 dark:to-zinc-800/60"
+      )}>
         <div className="flex flex-row items-center justify-between">
           <div className="flex items-center gap-2">
-            <div className="relative p-2 rounded-xl bg-gradient-to-br from-green-500/20 to-green-600/10 border border-green-500/20">
+            <div className={cn(
+              "relative p-2 rounded-xl border transition-colors",
+              completedTasks === totalTasks && totalTasks > 0
+                ? "bg-gradient-to-br from-green-500/30 to-green-600/20 border-green-500/30"
+                : "bg-gradient-to-br from-green-500/20 to-green-600/10 border-green-500/20"
+            )}>
               <ListTodo className="w-5 h-5 text-green-500 dark:text-green-400" />
             </div>
             <div>
-              <CardTitle className="text-base font-medium text-zinc-900 dark:text-zinc-100">
-                {toolTitle}
+              <CardTitle className={cn(
+                "text-base font-medium transition-colors",
+                completedTasks === totalTasks && totalTasks > 0
+                  ? "text-green-800 dark:text-green-300"
+                  : "text-zinc-900 dark:text-zinc-100"
+              )}>
+                {completedTasks === totalTasks && totalTasks > 0 ? "✅ " : ""}{toolTitle}
+                {completedTasks === totalTasks && totalTasks > 0 ? " - COMPLETED" : ""}
               </CardTitle>
             </div>
           </div>
@@ -174,7 +220,12 @@ export const TaskListToolView: React.FC<ToolViewProps> = ({
         )}
       </CardContent>
 
-      <div className="px-4 py-2 h-10 bg-gradient-to-r from-zinc-50/90 to-zinc-100/90 dark:from-zinc-900/90 dark:to-zinc-800/90 backdrop-blur-sm border-t border-zinc-200 dark:border-zinc-800 flex justify-between items-center gap-4">
+      <div className={cn(
+        "px-4 py-2 h-10 bg-gradient-to-r backdrop-blur-sm border-t flex justify-between items-center gap-4 transition-colors",
+        completedTasks === totalTasks && totalTasks > 0
+          ? "from-green-50/90 to-green-100/90 dark:from-green-900/90 dark:to-green-800/90 border-green-200 dark:border-green-800"
+          : "from-zinc-50/90 to-zinc-100/90 dark:from-zinc-900/90 dark:to-zinc-800/90 border-zinc-200 dark:border-zinc-800"
+      )}>
         <div className="h-full flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
           {!isStreaming && hasData && (
             <div className="flex items-center gap-2">
@@ -183,9 +234,9 @@ export const TaskListToolView: React.FC<ToolViewProps> = ({
                 {sections.length} sections
               </Badge>
               {completedTasks === totalTasks && totalTasks > 0 && (
-                <Badge variant="outline" className="h-6 py-0.5 bg-green-50 text-green-700 border-green-200">
+                <Badge variant="outline" className="h-6 py-0.5 bg-green-100 text-green-800 border-green-300 dark:bg-green-800/30 dark:text-green-300 dark:border-green-700">
                   <Check className="h-3 w-3" />
-                  All complete
+                  🎉 All complete!
                 </Badge>
               )}
             </div>

--- a/frontend/src/components/ui/editable-markdown.tsx
+++ b/frontend/src/components/ui/editable-markdown.tsx
@@ -98,7 +98,40 @@ export const EditableMarkdown: React.FC<EditableMarkdownProps> = ({
               p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
               ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-1">{children}</ul>,
               ol: ({ children }) => <ol className="list-decimal list-inside mb-2 space-y-1">{children}</ol>,
-              li: ({ children }) => <li className="text-sm">{children}</li>,
+              li: ({ children }) => {
+                // Check if this is a task list item (contains [x] or [ ])
+                const content = children as string;
+                const isTaskList = typeof content === 'string' && /^\[[ x]\]\s/.test(content);
+                
+                if (isTaskList) {
+                  const isCompleted = content.startsWith('[x]');
+                  const taskText = content.replace(/^\[[ x]\]\s/, '');
+                  
+                  return (
+                    <li className="flex items-start gap-3 my-2">
+                      <div className="flex-shrink-0 mt-0.5">
+                        {isCompleted ? (
+                          <div className="w-4 h-4 rounded border-2 border-green-500 bg-green-500 flex items-center justify-center">
+                            <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                              <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                            </svg>
+                          </div>
+                        ) : (
+                          <div className="w-4 h-4 rounded border-2 border-zinc-400 dark:border-zinc-600 bg-transparent" />
+                        )}
+                      </div>
+                      <span className={cn(
+                        "flex-1",
+                        isCompleted && "text-green-700 dark:text-green-300 line-through"
+                      )}>
+                        {taskText}
+                      </span>
+                    </li>
+                  );
+                }
+                
+                return <li className="text-sm">{children}</li>;
+              },
               code: ({ children, className }) => {
                 const isInline = !className?.includes('language-');
                 return isInline ? (

--- a/frontend/src/components/ui/expandable-markdown-editor.tsx
+++ b/frontend/src/components/ui/expandable-markdown-editor.tsx
@@ -97,7 +97,40 @@ export const ExpandableMarkdownEditor: React.FC<ExpandableMarkdownEditorProps> =
         p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
         ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-1">{children}</ul>,
         ol: ({ children }) => <ol className="list-decimal list-inside mb-2 space-y-1">{children}</ol>,
-        li: ({ children }) => <li className="text-sm">{children}</li>,
+        li: ({ children }) => {
+          // Check if this is a task list item (contains [x] or [ ])
+          const content = children as string;
+          const isTaskList = typeof content === 'string' && /^\[[ x]\]\s/.test(content);
+          
+          if (isTaskList) {
+            const isCompleted = content.startsWith('[x]');
+            const taskText = content.replace(/^\[[ x]\]\s/, '');
+            
+            return (
+              <li className="flex items-start gap-3 my-2">
+                <div className="flex-shrink-0 mt-0.5">
+                  {isCompleted ? (
+                    <div className="w-4 h-4 rounded border-2 border-green-500 bg-green-500 flex items-center justify-center">
+                      <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                      </svg>
+                    </div>
+                  ) : (
+                    <div className="w-4 h-4 rounded border-2 border-zinc-400 dark:border-zinc-600 bg-transparent" />
+                  )}
+                </div>
+                <span className={cn(
+                  "flex-1",
+                  isCompleted && "text-green-700 dark:text-green-300 line-through"
+                )}>
+                  {taskText}
+                </span>
+              </li>
+            );
+          }
+          
+          return <li className="text-sm">{children}</li>;
+        },
         code: ({ children, className }) => {
           const isInline = !className?.includes('language-');
           return isInline ? (

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -24,7 +24,40 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
           p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
           ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-1">{children}</ul>,
           ol: ({ children }) => <ol className="list-decimal list-inside mb-2 space-y-1">{children}</ol>,
-          li: ({ children }) => <li className="text-sm">{children}</li>,
+          li: ({ node, ...props }) => {
+              // Check if this is a task list item (contains [x] or [ ])
+              const content = props.children as string;
+              const isTaskList = typeof content === 'string' && /^\[[ x]\]\s/.test(content);
+              
+              if (isTaskList) {
+                const isCompleted = content.startsWith('[x]');
+                const taskText = content.replace(/^\[[ x]\]\s/, '');
+                
+                return (
+                  <li className="flex items-start gap-3 my-2" {...props}>
+                    <div className="flex-shrink-0 mt-0.5">
+                      {isCompleted ? (
+                        <div className="w-4 h-4 rounded border-2 border-green-500 bg-green-500 flex items-center justify-center">
+                          <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                          </svg>
+                        </div>
+                      ) : (
+                        <div className="w-4 h-4 rounded border-2 border-zinc-400 dark:border-zinc-600 bg-transparent" />
+                      )}
+                    </div>
+                    <span className={cn(
+                      "flex-1",
+                      isCompleted && "text-green-700 dark:text-green-300 line-through"
+                    )}>
+                      {taskText}
+                    </span>
+                  </li>
+                );
+              }
+              
+              return <li className="my-1" {...props} />;
+            },
           code: ({ children, className }) => {
             const isInline = !className?.includes('language-');
             return isInline ? (

--- a/frontend/src/components/ui/markdown.tsx
+++ b/frontend/src/components/ui/markdown.tsx
@@ -74,6 +74,37 @@ const INITIAL_COMPONENTS: Partial<Components> = {
     );
   },
   li: function ListItem({ children, ...props }: any) {
+    // Check if this is a task list item (contains [x] or [ ])
+    const content = children as string;
+    const isTaskList = typeof content === 'string' && /^\[[ x]\]\s/.test(content);
+    
+    if (isTaskList) {
+      const isCompleted = content.startsWith('[x]');
+      const taskText = content.replace(/^\[[ x]\]\s/, '');
+      
+      return (
+        <li className="flex items-start gap-3 my-2" {...props}>
+          <div className="flex-shrink-0 mt-0.5">
+            {isCompleted ? (
+              <div className="w-4 h-4 rounded border-2 border-green-500 bg-green-500 flex items-center justify-center">
+                <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              </div>
+            ) : (
+              <div className="w-4 h-4 rounded border-2 border-zinc-400 dark:border-zinc-600 bg-transparent" />
+            )}
+          </div>
+          <span className={cn(
+            "flex-1",
+            isCompleted && "text-green-700 dark:text-green-300 line-through"
+          )}>
+            {taskText}
+          </span>
+        </li>
+      );
+    }
+    
     return (
       <li className="my-1" {...props}>
         {children}


### PR DESCRIPTION
This PR fixes the markdown rendering issue where task lists were displaying as raw text instead of properly rendered checkboxes. Previously, `[x]` and `[ ]` task list items were showing as plain text, making it difficult to distinguish between completed and pending tasks.